### PR TITLE
Added --limit=<seconds> flag to csv export. (Includes tests.)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "substudy"
 version = "0.4.1"
 dependencies = [
  "cld2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cli_test_dir 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cli_test_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "cli_test_dir"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -449,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum cld2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5820703dfcb79253d9ccce414db29d34fff0a85d62a1914921f7468026567ee5"
 "checksum cld2-sys 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01081c29c4c4908bbf477dc43df0b5b648dfa09f7e3bf97d085dc373b4351339"
-"checksum cli_test_dir 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc5c0e759bbcea5820490a287e4fee5e259bc4308478fd890552bee2d61b4455"
+"checksum cli_test_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d007f296318f655a55cd63548d04729bf3d482fe779109c2d82716b305429db"
 "checksum cmake 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "e1acc68a3f714627af38f9f5d09706a28584ba60dfe2cca68f40bf779f941b25"
 "checksum csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "266c1815d7ca63a5bd86284043faf91e8c95e943e55ce05dc0ae08e952de18bc"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "0.1.41"
 uchardet = "2.0.0"
 
 [dev-dependencies]
-cli_test_dir = "0.1"
+cli_test_dir = "0.1.2"
 difference = "0.4.1"
 
 [[bin]]

--- a/src/bin/substudy.rs
+++ b/src/bin/substudy.rs
@@ -21,7 +21,7 @@ Subtitle processing tools for students of foreign languages
 
 Usage: substudy clean <subs>
        substudy combine <foreign-subs> <native-subs>
-       substudy export csv <video> <foreign-subs> [<native-subs>]
+       substudy export csv [--limit=<secs>] <video> <foreign-subs> [<native-subs>]
        substudy export review <video> <foreign-subs> [<native-subs>]
        substudy export tracks <video> <foreign-subs>
        substudy list tracks <video>
@@ -45,6 +45,7 @@ struct Args {
     arg_foreign_subs: String,
     arg_native_subs: Option<String>,
     arg_video: String,
+    flag_limit: Option<f32>,
     flag_version: bool,
 }
 
@@ -73,7 +74,8 @@ fn run(args: &Args) -> Result<()> {
         {
             cmd_export(export_type(args), &Path::new(video_path),
                        &Path::new(foreign_path),
-                       native_path.as_ref().map(|p| Path::new(p)))
+                       native_path.as_ref().map(|p| Path::new(p)),
+                       args.flag_limit)
         }
         Args{cmd_tracks: true, arg_video: ref path, ..} =>
             cmd_tracks(&Path::new(path)),
@@ -111,7 +113,8 @@ fn cmd_tracks(path: &Path) -> Result<()> {
 }
 
 fn cmd_export(kind: &str, video_path: &Path, foreign_sub_path: &Path,
-              native_sub_path: Option<&Path>) ->
+              native_sub_path: Option<&Path>,
+              limit: Option<f32>) ->
     Result<()>
 {
     // Load our input files.
@@ -123,7 +126,7 @@ fn cmd_export(kind: &str, video_path: &Path, foreign_sub_path: &Path,
     };
 
     let mut exporter =
-        try!(export::Exporter::new(video, foreign_subs, native_subs, kind));
+        try!(export::Exporter::new(video, foreign_subs, native_subs, kind, limit));
     match kind {
         "csv" => try!(export::export_csv(&mut exporter)),
         "review" => try!(export::export_review(&mut exporter)),

--- a/src/bin/substudy.rs
+++ b/src/bin/substudy.rs
@@ -21,9 +21,9 @@ Subtitle processing tools for students of foreign languages
 
 Usage: substudy clean <subs>
        substudy combine <foreign-subs> <native-subs>
-       substudy export csv [--limit=<secs>] <video> <foreign-subs> [<native-subs>]
-       substudy export review <video> <foreign-subs> [<native-subs>]
-       substudy export tracks <video> <foreign-subs>
+       substudy export csv [--end-at=<secs>] <video> <foreign-subs> [<native-subs>]
+       substudy export review [--end-at=<secs>] <video> <foreign-subs> [<native-subs>]
+       substudy export tracks [--end-at=<secs>] <video> <foreign-subs>
        substudy list tracks <video>
        substudy --help
        substudy --version
@@ -45,7 +45,7 @@ struct Args {
     arg_foreign_subs: String,
     arg_native_subs: Option<String>,
     arg_video: String,
-    flag_limit: Option<f32>,
+    flag_end_at: Option<f32>,
     flag_version: bool,
 }
 
@@ -75,7 +75,7 @@ fn run(args: &Args) -> Result<()> {
             cmd_export(export_type(args), &Path::new(video_path),
                        &Path::new(foreign_path),
                        native_path.as_ref().map(|p| Path::new(p)),
-                       args.flag_limit)
+                       args.flag_end_at)
         }
         Args{cmd_tracks: true, arg_video: ref path, ..} =>
             cmd_tracks(&Path::new(path)),
@@ -114,7 +114,7 @@ fn cmd_tracks(path: &Path) -> Result<()> {
 
 fn cmd_export(kind: &str, video_path: &Path, foreign_sub_path: &Path,
               native_sub_path: Option<&Path>,
-              limit: Option<f32>) ->
+              end_at: Option<f32>) ->
     Result<()>
 {
     // Load our input files.
@@ -126,7 +126,7 @@ fn cmd_export(kind: &str, video_path: &Path, foreign_sub_path: &Path,
     };
 
     let mut exporter =
-        try!(export::Exporter::new(video, foreign_subs, native_subs, kind, limit));
+        try!(export::Exporter::new(video, foreign_subs, native_subs, kind, end_at));
     match kind {
         "csv" => try!(export::export_csv(&mut exporter)),
         "review" => try!(export::export_review(&mut exporter)),

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -44,6 +44,7 @@ struct AnkiNote {
 /// Export the video and subtitles as a CSV file with accompanying media
 /// files, for import into Anki.
 pub fn export_csv(exporter: &mut Exporter) -> Result<()> {
+    let processing_limit = exporter.processing_limit();
     let foreign_lang = exporter.foreign().language;
     let prefix = episode_prefix(exporter.file_stem());
 
@@ -72,6 +73,14 @@ pub fn export_csv(exporter: &mut Exporter) -> Result<()> {
         let native = ctx.map(|&(_, ref n)| n).flatten();
 
         if let Some(curr) = foreign.curr {
+            match processing_limit {
+                Some(seconds) if curr.period.begin() > seconds => {
+                    println!("Limiting to {:?} seconds of video.", seconds);
+                    break;
+                }
+                _ => {}
+            }
+
             let period = curr.period.grow(1.5, 1.5);
 
             let image_path = exporter.schedule_image_export(period.midpoint());

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -44,7 +44,7 @@ struct AnkiNote {
 /// Export the video and subtitles as a CSV file with accompanying media
 /// files, for import into Anki.
 pub fn export_csv(exporter: &mut Exporter) -> Result<()> {
-    let processing_limit = exporter.processing_limit();
+    let end_at = exporter.end_at();
     let foreign_lang = exporter.foreign().language;
     let prefix = episode_prefix(exporter.file_stem());
 
@@ -73,9 +73,9 @@ pub fn export_csv(exporter: &mut Exporter) -> Result<()> {
         let native = ctx.map(|&(_, ref n)| n).flatten();
 
         if let Some(curr) = foreign.curr {
-            match processing_limit {
+            match end_at {
                 Some(seconds) if curr.period.begin() > seconds => {
-                    println!("Limiting to {:?} seconds of video.", seconds);
+                    println!("Ending at {:?} seconds of video.", seconds);
                     break;
                 }
                 _ => {}

--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -63,8 +63,9 @@ pub struct Exporter {
     /// efficiently as possible.
     extractions: Vec<Extraction>,
 
-    /// The number of seconds to limit processing to.
-    processing_limit: Option<f32>,
+    /// The number of seconds to end processing at. If not set,
+    /// process the entire video.
+    end_at: Option<f32>,
 }
 
 impl Exporter {
@@ -75,7 +76,7 @@ impl Exporter {
                foreign_subtitles: SubtitleFile,
                native_subtitles: Option<SubtitleFile>,
                label: &str,
-               processing_limit: Option<f32>) ->
+               end_at: Option<f32>) ->
         Result<Exporter>
     {
         let foreign = LanguageResources::new(foreign_subtitles);
@@ -104,7 +105,7 @@ impl Exporter {
             file_stem: file_stem,
             dir: dir,
             extractions: vec!(),
-            processing_limit: processing_limit,
+            end_at: end_at,
         })
     }
 
@@ -134,9 +135,9 @@ impl Exporter {
         self.native.as_ref()
     }
 
-    /// Get the seconds to limit processing to.
-    pub fn processing_limit(&self) -> Option<f32> {
-        self.processing_limit
+    /// Get the number of seconds to end processing at.
+    pub fn end_at(&self) -> Option<f32> {
+        self.end_at
     }
 
     /// Align our two sets of subtitles.

--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -62,6 +62,9 @@ pub struct Exporter {
     /// A list of media files we want to extract from our video as
     /// efficiently as possible.
     extractions: Vec<Extraction>,
+
+    /// The number of seconds to limit processing to.
+    processing_limit: Option<f32>,
 }
 
 impl Exporter {
@@ -71,7 +74,8 @@ impl Exporter {
     pub fn new(video: Video,
                foreign_subtitles: SubtitleFile,
                native_subtitles: Option<SubtitleFile>,
-               label: &str) ->
+               label: &str,
+               processing_limit: Option<f32>) ->
         Result<Exporter>
     {
         let foreign = LanguageResources::new(foreign_subtitles);
@@ -100,6 +104,7 @@ impl Exporter {
             file_stem: file_stem,
             dir: dir,
             extractions: vec!(),
+            processing_limit: processing_limit,
         })
     }
 
@@ -127,6 +132,11 @@ impl Exporter {
     /// Get data related to the native language.
     pub fn native(&self) -> Option<&LanguageResources> {
         self.native.as_ref()
+    }
+
+    /// Get the seconds to limit processing to.
+    pub fn processing_limit(&self) -> Option<f32> {
+        self.processing_limit
     }
 
     /// Align our two sets of subtitles.

--- a/src/export/review.rs
+++ b/src/export/review.rs
@@ -54,6 +54,7 @@ impl ToJson for ExportInfo {
 
 /// Export the video and subtitles as a web page in "reviewable" format.
 pub fn export_review(exporter: &mut Exporter) -> Result<()> {
+    let end_at = exporter.end_at();
     let foreign_lang = exporter.foreign().language;
     // Start preparing information we'll pass to our HTML template.
     let mut bindings = ExportInfo {
@@ -72,6 +73,14 @@ pub fn export_review(exporter: &mut Exporter) -> Result<()> {
             foreign.as_ref().map(|s| s.period),
             native.as_ref().map(|s| s.period),
         ).expect("subtitle pair must not be empty").grow(0.5, 0.5);
+
+        match end_at {
+            Some(seconds) if period.begin() > seconds => {
+                println!("Ending at {:?} seconds of video.", seconds);
+                break;
+            }
+            _ => {}
+        }
 
         let image_path = exporter.schedule_image_export(period.midpoint());
         let audio_path = exporter.schedule_audio_export(foreign_lang, period);

--- a/src/export/tracks.rs
+++ b/src/export/tracks.rs
@@ -85,11 +85,20 @@ pub fn export_tracks(exporter: &mut Exporter) -> Result<()> {
     // UTF-8).
     //
     // TODO: Genre, artist, album, track title, track number.
+    let end_at = exporter.end_at();
     let foreign_lang = exporter.foreign().language;
     let mut playlist = Cursor::new(vec!());
     for (i, conv) in convs.iter().enumerate() {
         debug!("Conv: {:7.1} -> {:7.1} for {:7.1}",
                conv.period.begin(), conv.period.end(), conv.period.duration());
+
+        match end_at {
+            Some(seconds) if conv.period.begin() > seconds => {
+                println!("Ending at {:?} seconds of video.", seconds);
+                break;
+            }
+            _ => {}
+        }
 
         // Build our track name.
         let name = format!("{} {}", seconds_to_hhmmss(conv.period.begin()),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,6 +54,10 @@ fn cmd_combine() {
     assert!(from_utf8(&output.stdout).unwrap().find("¡Si!").is_some());
 }
 
+static FIRST_LINE: &'static str = "[sound:empty_00060_828-00066_164.es.mp3],0:01:00.828,empty,\"<img src=\"\"empty_00063_496.jpg\"\" />\",¡Si! ¡Aang ha vuelto!,Yay! Yay! Aang\'s back!,,,¡Lo sabía!,I knew it!\n";
+
+static LAST_LINE: &'static str = "[sound:empty_00077_124-00083_379.es.mp3],0:01:17.124,empty,\"<img src=\"\"empty_00080_251.jpg\"\" />\",\"El no ha hecho nada, Sokka, fué un accidente.\",Aang didn\'t do anything.,harás que vengan a nosotros.,\"You\'re leading them straight to us, aren\'t you?\",,\n";
+
 #[test]
 fn cmd_export_csv() {
     let testdir = TestDir::new("substudy", "cmd_export_csv");
@@ -68,7 +72,27 @@ fn cmd_export_csv() {
     testdir.expect_path("empty_csv/cards.csv");
     testdir.expect_path("empty_csv/empty_00063_496.jpg");
     testdir.expect_path("empty_csv/empty_00060_828-00066_164.es.mp3");
+    testdir.expect_contains("empty_csv/cards.csv", FIRST_LINE);
+    testdir.expect_contains("empty_csv/cards.csv", LAST_LINE);
 }
+
+#[test]
+fn cmd_export_csv_limit() {
+    let testdir = TestDir::new("substudy", "cmd_export_csv_limit");
+    let output = testdir.cmd()
+        .args(&["export", "csv", "--limit=65"])
+        .arg(testdir.src_path("fixtures/empty.mp4"))
+        .arg(testdir.src_path("fixtures/sample.es.srt"))
+        .arg(testdir.src_path("fixtures/sample.en.srt"))
+        .output()
+        .expect("could not run substudy");
+    assert!(output.status.success());
+    testdir.expect_path("empty_csv/cards.csv");
+    testdir.expect_path("empty_csv/empty_00063_496.jpg");
+    testdir.expect_path("empty_csv/empty_00060_828-00066_164.es.mp3");
+    testdir.expect_file_contents("empty_csv/cards.csv", FIRST_LINE);
+}
+
 
 #[test]
 fn cmd_export_review() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,9 +54,9 @@ fn cmd_combine() {
     assert!(from_utf8(&output.stdout).unwrap().find("¡Si!").is_some());
 }
 
-static FIRST_LINE: &'static str = "[sound:empty_00060_828-00066_164.es.mp3],0:01:00.828,empty,\"<img src=\"\"empty_00063_496.jpg\"\" />\",¡Si! ¡Aang ha vuelto!,Yay! Yay! Aang\'s back!,,,¡Lo sabía!,I knew it!\n";
+static FIRST_LINE: &'static str = "¡Si! ¡Aang ha vuelto!,Yay! Yay! Aang\'s back!,,,¡Lo sabía!,I knew it!";
 
-static LAST_LINE: &'static str = "[sound:empty_00077_124-00083_379.es.mp3],0:01:17.124,empty,\"<img src=\"\"empty_00080_251.jpg\"\" />\",\"El no ha hecho nada, Sokka, fué un accidente.\",Aang didn\'t do anything.,harás que vengan a nosotros.,\"You\'re leading them straight to us, aren\'t you?\",,\n";
+static LAST_LINE: &'static str = "\"El no ha hecho nada, Sokka, fué un accidente.\",Aang didn\'t do anything.,harás que vengan a nosotros.,\"You\'re leading them straight to us, aren\'t you?\"";
 
 #[test]
 fn cmd_export_csv() {
@@ -77,10 +77,10 @@ fn cmd_export_csv() {
 }
 
 #[test]
-fn cmd_export_csv_limit() {
-    let testdir = TestDir::new("substudy", "cmd_export_csv_limit");
+fn cmd_export_csv_end_at() {
+    let testdir = TestDir::new("substudy", "cmd_export_csv_end_at");
     let output = testdir.cmd()
-        .args(&["export", "csv", "--limit=65"])
+        .args(&["export", "csv", "--end-at=65"])
         .arg(testdir.src_path("fixtures/empty.mp4"))
         .arg(testdir.src_path("fixtures/sample.es.srt"))
         .arg(testdir.src_path("fixtures/sample.en.srt"))
@@ -90,9 +90,8 @@ fn cmd_export_csv_limit() {
     testdir.expect_path("empty_csv/cards.csv");
     testdir.expect_path("empty_csv/empty_00063_496.jpg");
     testdir.expect_path("empty_csv/empty_00060_828-00066_164.es.mp3");
-    testdir.expect_file_contents("empty_csv/cards.csv", FIRST_LINE);
+    testdir.expect_contains("empty_csv/cards.csv", FIRST_LINE);
 }
-
 
 #[test]
 fn cmd_export_review() {
@@ -111,10 +110,40 @@ fn cmd_export_review() {
 }
 
 #[test]
+fn cmd_export_review_end_at() {
+    let testdir = TestDir::new("substudy", "cmd_export_review_end_at");
+    let output = testdir.cmd()
+        .args(&["export", "review", "--end-at=65"])
+        .arg(testdir.src_path("fixtures/empty.mp4"))
+        .arg(testdir.src_path("fixtures/sample.es.srt"))
+        .arg(testdir.src_path("fixtures/sample.en.srt"))
+        .output()
+        .expect("could not run substudy");
+    assert!(output.status.success());
+    testdir.expect_path("empty_review/index.html");
+    testdir.expect_path("empty_review/empty_00063_496.jpg");
+    testdir.expect_path("empty_review/empty_00061_828-00065_164.es.mp3");
+}
+
+#[test]
 fn cmd_export_tracks() {
     let testdir = TestDir::new("substudy", "cmd_export_tracks");
     let output = testdir.cmd()
         .args(&["export", "tracks"])
+        .arg(testdir.src_path("fixtures/empty.mp4"))
+        .arg(testdir.src_path("fixtures/sample.es.srt"))
+        .output()
+        .expect("could not run substudy");
+    assert!(output.status.success());
+    testdir.expect_path("empty_tracks/playlist.m3u8");
+    testdir.expect_path("empty_tracks/empty_00059_828-00067_164.es.mp3");
+}
+
+#[test]
+fn cmd_export_tracks_end_at() {
+    let testdir = TestDir::new("substudy", "cmd_export_tracks_end_at");
+    let output = testdir.cmd()
+        .args(&["export", "tracks", "--end-at=65"])
         .arg(testdir.src_path("fixtures/empty.mp4"))
         .arg(testdir.src_path("fixtures/sample.es.srt"))
         .output()


### PR DESCRIPTION
Addresses (my own) feature request #14.

Added `--limit=<seconds>` flag to csv export. Only the first seconds will be processed, then substudy will stop early. Useful when testing a new file or subtitle timing.

Added tests to confirm that the generated csv contains expected data.

Bumped cli_test_dir to version 0.1.2 to take advantage of new `expect_file_contents` and `expect_contains` methods.