### PR TITLE
Vobsub: allow parsing input stream by chunks

### DIFF
--- a/vobsub/src/lib.rs
+++ b/vobsub/src/lib.rs
@@ -102,4 +102,4 @@ mod util;
 pub use common_failures::{Error, Result};
 pub use self::idx::{Index, Palette};
 pub use self::probe::{is_idx_file, is_sub_file};
-pub use self::sub::{Coordinates, Subtitle, Subtitles, subtitles};
+pub use self::sub::{Coordinates, Subtitle, Subtitles, SubtitlesFromChunks, subtitles};

--- a/vobsub/src/mpeg2/pes.rs
+++ b/vobsub/src/mpeg2/pes.rs
@@ -282,6 +282,10 @@ named!(packet_helper<Packet>,
     )
 );
 
+/// Minimum needed length to identify a new PES Packet header
+/// and get its length.
+pub const PES_PACKET_HEADER_MIN_LEN: usize = 4 + 2;
+
 named!(pub packet<Packet>,
     do_parse!(
         tag!(&[0x00, 0x00, 0x01, 0xbd]) >>

--- a/vobsub/src/mpeg2/ps.rs
+++ b/vobsub/src/mpeg2/ps.rs
@@ -3,8 +3,9 @@
 //! This is the container format used at the top-level of a `*.sub` file.
 
 use common_failures::prelude::*;
-use nom::IResult;
+use nom::{IResult, Needed};
 use std::fmt;
+use std::ops::Deref;
 
 use super::clock::{Clock, clock_and_ext};
 use super::pes;
@@ -82,10 +83,58 @@ named!(pub pes_packet<PesPacket>,
     )
 );
 
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NeededOpt(Option<usize>);
+
+impl From<Needed> for NeededOpt {
+    fn from(needed: Needed) -> Self {
+        match needed {
+            Needed::Size(needed) => NeededOpt(Some(needed)),
+            Needed::Unknown => NeededOpt(None),
+        }
+    }
+}
+
+impl From<Option<usize>> for NeededOpt {
+    fn from(needed: Option<usize>) -> Self {
+        NeededOpt(needed)
+    }
+}
+
+impl From<NeededOpt> for Option<usize> {
+    fn from(needed: NeededOpt) -> Self {
+        needed.0
+    }
+}
+
+impl Deref for NeededOpt {
+    type Target = Option<usize>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Fail)]
+pub enum PesPacketError {
+    #[fail(display = "Incomplete PES packet: offset {}, needed {:?}", offset, needed)]
+    Incomplete {
+        offset: usize,
+        needed: NeededOpt,
+    },
+    #[fail(display = "PES packet needle not found: offset {}, remaining {}", offset, remaining)]
+    NeedleNotFound {
+        offset: usize,
+        remaining: usize,
+    },
+}
+
 /// An iterator over all the PES packets in an MPEG-2 Program Stream.
 pub struct PesPackets<'a> {
     /// The remaining input to parse.
     remaining: &'a [u8],
+    /// The offset of the remaining input in the initial slice
+    pub offset: usize,
 }
 
 impl<'a> Iterator for PesPackets<'a> {
@@ -100,10 +149,12 @@ impl<'a> Iterator for PesPackets<'a> {
 
             if let Some(start) = start {
                 // We found the start, so try to parse it.
+                self.offset += start;
                 self.remaining = &self.remaining[start..];
                 match pes_packet(self.remaining) {
                     // We found a packet!
                     IResult::Done(remaining, packet) => {
+                        self.offset += self.remaining.len() - remaining.len();
                         self.remaining = remaining;
                         trace!("Decoded packet {:?}", &packet);
                         return Some(Ok(packet));
@@ -112,21 +163,37 @@ impl<'a> Iterator for PesPackets<'a> {
                     // data.
                     IResult::Incomplete(needed) => {
                         self.remaining = &[];
-                        warn!("Incomplete packet, need: {:?}", needed);
-                        return Some(Err(format_err!("Incomplete PES packet")));
+                        let err = PesPacketError::Incomplete {
+                            offset: self.offset,
+                            needed: needed.into(),
+                        };
+                        warn!("{:?}", err);
+                        return Some(Err(Error::from(err)));
                     }
                     // We got something that looked like a packet but
                     // wasn't parseable.  Log it and keep trying.
                     IResult::Error(err) => {
+                        self.offset += needle.len();
                         self.remaining = &self.remaining[needle.len()..];
                         debug!("Skipping packet {:?}", &err);
                     }
                 }
             } else {
                 // We didn't find the start of a packet.
+                let remaining_len = self.remaining.len();
                 self.remaining = &[];
-                trace!("Reached end of data");
-                return None;
+
+                if remaining_len > 0 {
+                    let err = PesPacketError::NeedleNotFound {
+                        offset: self.offset,
+                        remaining: remaining_len,
+                    };
+                    debug!("{:?}", err);
+                    return Some(Err(Error::from(err)));
+                } else {
+                    trace!("Reached end of data");
+                    return None;
+                }
             }
         }
     }
@@ -135,5 +202,8 @@ impl<'a> Iterator for PesPackets<'a> {
 /// Iterate over all the PES packets in an MPEG-2 Program Stream (or at
 /// least those which contain subtitles).
 pub fn pes_packets(input: &[u8]) -> PesPackets {
-    PesPackets { remaining: input }
+    PesPackets {
+        remaining: input,
+        offset: 0,
+    }
 }

--- a/vobsub/src/mpeg2/ps.rs
+++ b/vobsub/src/mpeg2/ps.rs
@@ -101,6 +101,12 @@ impl From<Option<usize>> for NeededOpt {
     }
 }
 
+impl From<usize> for NeededOpt {
+    fn from(needed: usize) -> Self {
+        NeededOpt(Some(needed))
+    }
+}
+
 impl From<NeededOpt> for Option<usize> {
     fn from(needed: NeededOpt) -> Self {
         needed.0
@@ -128,6 +134,9 @@ pub enum PesPacketError {
         remaining: usize,
     },
 }
+
+/// The length for the needle introducing a Program Stream packet.
+pub const PES_PACKET_NEEDLE_LEN: usize = 4;
 
 /// An iterator over all the PES packets in an MPEG-2 Program Stream.
 pub struct PesPackets<'a> {

--- a/vobsub/src/sub.rs
+++ b/vobsub/src/sub.rs
@@ -8,11 +8,15 @@ use cast;
 use common_failures::prelude::*;
 use nom::{be_u16, IResult};
 use std::fmt;
+use std::rc::Rc;
+use std::cell::RefCell;
 
+use errors::VobsubError;
 use idx;
 use image::{ImageBuffer, Rgba, RgbaImage};
 use img::{decompress, Size};
 use mpeg2::ps;
+use mpeg2::ps::{NeededOpt, PesPacketError};
 use util::BytesFormatter;
 
 /// The default time between two adjacent subtitles if no end time is
@@ -496,16 +500,138 @@ fn subtitle(raw_data: &[u8], base_time: f64) -> Result<Subtitle> {
     Ok(result)
 }
 
-/// Like `?` and `try!`, but assume that we're working with
-/// `Option<Result<T, E>>` instead of `Result<T, E>`, and pass through
-/// `None`.
-macro_rules! try_iter {
-    ($e:expr) => {
-        match $e {
-            None => return None,
-            Some(Err(e)) => return Some(Err(From::from(e))),
-            Some(Ok(value)) => value,
+struct PartialSubtitle {
+    packets_data: Vec<u8>,
+    base_time: f64,
+    substream_id: u8,
+    wanted: usize,
+}
+
+impl PartialSubtitle {
+    fn new(packet: ps::PesPacket) -> Result<Self> {
+        let pts_dts = match packet.pes_packet.header_data.pts_dts {
+            Some(v) => v,
+            None => return Err(format_err!("Found subtitle without timing info")),
+        };
+
+        // Figure out how many total bytes we'll need to collect from one
+        // or more PES packets, and collect the first chunk into a buffer.
+        if packet.pes_packet.data.len() < 2 {
+            return Err(Error::from(VobsubError::IncompleteInput { needed: Some(2).into() } ));
         }
+
+        Ok(PartialSubtitle {
+            packets_data: packet.pes_packet.data.to_owned(),
+            base_time: pts_dts.pts.to_seconds(),
+            substream_id: packet.pes_packet.substream_id,
+            wanted: usize::from(packet.pes_packet.data[0]) << 8
+                | usize::from(packet.pes_packet.data[1]),
+        })
+    }
+
+    fn have_packet(&mut self, packet: ps::PesPacket) -> bool {
+        // Make sure this is part of the same subtitle stream.  This is
+        // mostly just paranoia; I don't expect this to happen.
+        if packet.pes_packet.substream_id != self.substream_id {
+            warn!("Found subtitle for stream 0x{:x} while looking for 0x{:x}",
+                  packet.pes_packet.substream_id, self.substream_id);
+            return true;
+        }
+
+        // Add the extra bytes to our buffer.
+        self.packets_data.extend_from_slice(packet.pes_packet.data);
+
+        if !self.more_data_wanted() {
+            // Expected data retrieved.
+
+            // Check to make sure we didn't get too _many_ bytes.  Again, this
+            // is paranoia.
+            if self.packets_data.len() > self.wanted {
+                warn!("Found 0x{:x} bytes of data in subtitle packet, wanted 0x{:x}",
+                      self.packets_data.len(), self.wanted);
+                self.packets_data.truncate(self.wanted);
+            }
+
+            false
+        } else {
+            true
+        }
+    }
+
+    fn more_data_wanted(&self) -> bool {
+        self.packets_data.len() < self.wanted
+    }
+}
+
+/// A subtitle parsing context that keeps track of the parsing between chunks.
+#[derive(Default)]
+struct SubtitlesContext {
+    is_chunked: bool,
+    offset: usize,
+    needed: NeededOpt,
+    partial_subtitle: Option<PartialSubtitle>,
+}
+
+impl SubtitlesContext {
+    /// Handle this new packet.
+    /// Return `Ok(Some(partial_subtitle))` if the subtitle data is complete,
+    /// and `Ok(None)` if other packets are needed.
+    fn have_packet(
+        &mut self,
+        packet: ps::PesPacket,
+        new_offset: usize,
+    ) -> Result<Option<PartialSubtitle>> {
+        self.pepare_for_new_packet();
+
+        if self.partial_subtitle.is_none() {
+            // First packet.
+            match PartialSubtitle::new(packet) {
+                Ok(partial_subtitle) => {
+                    self.offset = new_offset;
+                    if partial_subtitle.more_data_wanted() {
+                        self.partial_subtitle = Some(partial_subtitle);
+                        Ok(None)
+                    } else {
+                        Ok(Some(partial_subtitle))
+                    }
+                }
+                Err(err) => {
+                    if let Some(ref vobsub_err) = err.downcast_ref::<VobsubError>() {
+                        if let VobsubError::IncompleteInput { ref needed } = **vobsub_err {
+                            self.needed = *needed;
+                        }
+                    }
+                    return Err(err);
+                }
+            }
+        } else {
+            // Additional packet.
+            let more_data_wanted = self.partial_subtitle.as_mut().unwrap().have_packet(packet);
+            self.offset = new_offset;
+            if more_data_wanted {
+                Ok(None)
+            } else {
+                Ok(self.partial_subtitle.take())
+            }
+        }
+    }
+
+    fn pepare_for_new_chunk(&mut self) {
+        self.offset = 0;
+        self.pepare_for_new_packet();
+    }
+
+    fn pepare_for_new_packet(&mut self) {
+        self.needed = NeededOpt::default();
+    }
+
+    fn set_unrecoverable_error(&mut self) {
+        self.needed = NeededOpt::default();
+        self.partial_subtitle.take();
+    }
+
+    fn expecting_chunk(&self) -> bool {
+        self.needed.is_some() || self.partial_subtitle.is_some()
     }
 }
 
@@ -514,59 +640,81 @@ macro_rules! try_iter {
 /// see them.
 struct SubtitlesInternal<'a> {
     pes_packets: ps::PesPackets<'a>,
+    // We use `Rc<RefCell>>` for the `SubtitlesContext` because we have 2 use cases:
+    // 1. Full stream processing. The `SubtitlesContext` is valid
+    //    until the `Subtitles` instance is destroyed.
+    // 2. Chunk processing. The `Subtitles` instances liftetime is
+    //    tied to the input chunk's life time. The `SubtitlesContext`
+    //    outlives the `Subtitles` instances.
+    context: Rc<RefCell<SubtitlesContext>>,
+}
+
+impl<'a> SubtitlesInternal<'a> {
+    fn new(input: &'a [u8], context: &Rc<RefCell<SubtitlesContext>>) -> Self {
+        SubtitlesInternal {
+            pes_packets: ps::pes_packets(input),
+            context: context.clone(),
+        }
+    }
 }
 
 impl<'a> Iterator for SubtitlesInternal<'a> {
     type Item = Result<Subtitle>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Get the PES packet containing the first chunk of our subtitle.
-        let first: ps::PesPacket = try_iter!(self.pes_packets.next());
+        loop {
+            let packet: ps::PesPacket = match self.pes_packets.next() {
+                Some(Ok(value)) => value,
+                None => return None,
+                Some(Err(err)) => {
+                    if self.context.borrow().partial_subtitle.is_none() {
+                        // Update the offset in case packets were skipped.
+                        self.context.borrow_mut().offset = self.pes_packets.offset;
+                    }
 
-        // Fetch useful information from our first packet.
-        let pts_dts = match first.pes_packet.header_data.pts_dts {
-            Some(v) => v,
-            None => return Some(Err(format_err!("found subtitle without timing into"))),
-        };
-        let base_time = pts_dts.pts.to_seconds();
-        let substream_id = first.pes_packet.substream_id;
+                    match err.downcast::<PesPacketError>() {
+                        Ok(pes_pack_err) => {
+                            if !self.context.borrow().is_chunked {
+                                // Working with full stream.
+                                match pes_pack_err {
+                                    PesPacketError::NeedleNotFound { .. } => {
+                                        // No more packets could be found.
+                                        // Consider this as the end of stream.
+                                        return None;
+                                    }
+                                    PesPacketError::Incomplete { needed, .. } => {
+                                        self.context.borrow_mut().needed = needed;
+                                        return Some(Err(Error::from(
+                                            VobsubError::IncompleteInput { needed  }
+                                        )));
+                                    }
+                                }
+                            } else {
+                                // Incomplete packets are expected in chunked mode.
+                                if let PesPacketError::Incomplete { needed, .. } = pes_pack_err {
+                                    self.context.borrow_mut().needed = needed.into();
+                                }
+                                return None;
+                            }
+                        }
+                        Err(err) => {
+                            trace!("Unrecoverable error");
+                            self.context.borrow_mut().set_unrecoverable_error();
+                            return Some(Err(err));
+                        }
+                    }
+                }
+            };
 
-        // Figure out how many total bytes we'll need to collect from one
-        // or more PES packets, and collect the first chunk into a buffer.
-        if first.pes_packet.data.len() < 2 {
-            return Some(Err(format_err!("packet is too short")));
-        }
-        let wanted = usize::from(first.pes_packet.data[0]) << 8
-            | usize::from(first.pes_packet.data[1]);
-        let mut sub_packet = first.pes_packet.data.to_owned();
-
-        // Keep fetching more packets until we have enough.
-        while sub_packet.len() < wanted {
-            // Get the next PES packet in the Program Stream.
-            let next: ps::PesPacket = try_iter!(self.pes_packets.next());
-
-            // Make sure this is part of the same subtitle stream.  This is
-            // mostly just paranoia; I don't expect this to happen.
-            if next.pes_packet.substream_id != substream_id {
-                warn!("Found subtitle for stream 0x{:x} while looking for 0x{:x}",
-                      next.pes_packet.substream_id, substream_id);
-                continue;
+            match self.context.borrow_mut().have_packet(packet, self.pes_packets.offset) {
+                Ok(None) => (), // Expecting more data.
+                Ok(Some(subtitle_data)) => {
+                    // No more packet wanted. Parse the subtitle data retrieved.
+                    return Some(subtitle(&subtitle_data.packets_data, subtitle_data.base_time));
+                }
+                Err(err) => return Some(Err(err)),
             }
-
-            // Add the extra bytes to our buffer.
-            sub_packet.extend_from_slice(next.pes_packet.data);
         }
-
-        // Check to make sure we didn't get too _many_ bytes.  Again, this
-        // is paranoia.
-        if sub_packet.len() > wanted {
-            warn!("Found 0x{:x} bytes of data in subtitle packet, wanted 0x{:x}",
-                  sub_packet.len(), wanted);
-            sub_packet.truncate(wanted);
-        }
-
-        // Parse our subtitle buffer.
-        Some(subtitle(&sub_packet, base_time))
     }
 }
 
@@ -574,6 +722,7 @@ impl<'a> Iterator for SubtitlesInternal<'a> {
 pub struct Subtitles<'a> {
     internal: SubtitlesInternal<'a>,
     prev: Option<Subtitle>,
+    prev_error: Option<Error>,
 }
 
 impl<'a> Iterator for Subtitles<'a> {
@@ -584,6 +733,12 @@ impl<'a> Iterator for Subtitles<'a> {
     // I'm not even sure this is valid, but it has been observed in the
     // wild.
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(err) = self.prev_error.take() {
+            // Previous iter generated an error which propagation was delayed
+            // in order to send previous subtitle.
+            return Some(Err(err));
+        }
+
         // If we don't currently have a previous subtitle, attempt to fetch
         // one.
         if self.prev.is_none() {
@@ -610,10 +765,12 @@ impl<'a> Iterator for Subtitles<'a> {
                 self.prev = Some(curr);
                 Some(Ok(prev))
             }
-            // We encountered an error.  We could, I suppose, attempt to
-            // first return `self.prev` and save the error for next time,
-            // but that's too much trouble.
-            Some(Err(err)) => Some(Err(err)),
+            // We encountered an error.
+            Some(Err(err)) => {
+                // Save it for next iteration and return previous subtitle for now.
+                self.prev_error = Some(err);
+                Some(Ok(self.prev.take().unwrap()))
+            }
             // The only subtitle left to return is `self.prev`.
             None => {
                 self.prev.take().map(|mut sub| {
@@ -633,10 +790,114 @@ impl<'a> Iterator for Subtitles<'a> {
 /// Return an iterator over the subtitles in this data stream.
 pub fn subtitles(input: &[u8]) -> Subtitles {
     Subtitles {
-        internal: SubtitlesInternal {
-            pes_packets: ps::pes_packets(input)
-        },
+        internal: SubtitlesInternal::new(
+            input,
+            &Rc::new(RefCell::new(SubtitlesContext::default())),
+        ),
         prev: None,
+        prev_error: None,
+    }
+}
+
+/// Subtitles iter manager which can process stream chunks.
+///
+/// # Example
+///
+/// ```
+/// use vobsub::SubtitlesFromChunks;
+/// use std::fs;
+/// use std::io::prelude::*;
+///
+/// let mut f = fs::File::open("../fixtures/example.sub").unwrap();
+/// let mut buffer = vec![];
+/// f.read_to_end(&mut buffer).unwrap();
+/// let mut chunk_size = 2048;
+/// let mut lower_offset = 0;
+/// let mut upper_offset = 0;
+///
+/// let mut subs = SubtitlesFromChunks::new();
+/// while upper_offset < buffer.len() {
+///     lower_offset += subs.offset();
+///     upper_offset = (lower_offset + chunk_size).min(buffer.len());
+///
+///     let mut sub_iter = subs.iter(&buffer[lower_offset..upper_offset]);
+///     for sub in sub_iter.next() {
+///         let subtitle = sub.unwrap();
+///         // ... process `subtitle`
+///     }
+///
+///     if let Some(needed) = subs.needed() {
+///         chunk_size = chunk_size.max(needed);
+///     }
+/// }
+/// ```
+#[allow(dead_code)]
+pub struct SubtitlesFromChunks {
+    context: Rc<RefCell<SubtitlesContext>>,
+    had_chunk: bool,
+}
+
+#[allow(dead_code)]
+impl SubtitlesFromChunks {
+    /// Build a new `SubtitlesFromChunks`, a [`Subtitles`] iterator manager
+    /// capable of handling streams by chunks.
+    ///
+    /// [`Subtitles`]: struct.Subtitles.html
+    pub fn new() -> Self {
+        SubtitlesFromChunks {
+            context: Rc::new(RefCell::new(SubtitlesContext {
+                is_chunked: true,
+                .. SubtitlesContext::default()
+            })),
+            had_chunk: false,
+        }
+    }
+
+    /// Get a [`Subtitles`] iterator from this chunk.
+    /// The parsing context is preserved for subsequent chunks.
+    ///
+    /// It is up to the caller to provide a slice that includes the remaining bytes
+    /// from the [`offset`] reached after previous iteration.
+    ///
+    /// [`Subtitles`]: struct.Subtitles.html
+    /// [`offset`]: struct.SubtitlesFromChunks.html#method.offset
+    pub fn iter<'a>(&mut self, input: &'a [u8]) -> Subtitles<'a> {
+        self.context.borrow_mut().pepare_for_new_chunk();
+        self.had_chunk = true;
+
+        Subtitles {
+            internal: SubtitlesInternal::new(input, &self.context),
+            prev: None,
+            prev_error: None,
+        }
+    }
+
+    /// Get current `offset` in the input chunk.
+    ///
+    /// The next chunk should start from the bytes in input chunk starting at `offset`.
+    pub fn offset(&self) -> usize {
+        self.context.borrow().offset
+    }
+
+    /// Whether this [`SubtitlesFromChunks`] is expecting other chunks.
+    ///
+    /// This is `true` when the [`SubtitlesFromChunks`] is initialized,
+    /// and then everytime an incomplete packet is being processed.
+    /// The next chunk must include remaining bytes not processed yet
+    /// (use [`offset`] to determine the first offset to include).
+    ///
+    /// [`SubtitlesFromChunks`]: struct.SubtitlesFromChunks.html
+    /// [`offset`]: struct.SubtitlesFromChunks.html#method.offset
+    pub fn expecting_chunk(&self) -> bool {
+        self.context.borrow().expecting_chunk() || !self.had_chunk
+    }
+
+    /// Get the minimal needed bytes required to continue parsing the stream.
+    ///
+    /// The next chunk should contain at least the needed bytes otherwise
+    /// you might loop infinitely.
+    pub fn needed(&self) -> Option<usize> {
+        self.context.borrow().needed.into()
     }
 }
 
@@ -660,6 +921,7 @@ fn parse_subtitles() {
                Coordinates { x1: 750, y1: 916, x2: 1172, y2: 966 });
     assert_eq!(sub1.palette, [0,3,1,0]);
     assert_eq!(sub1.alpha, [15,15,15,0]);
+    assert_eq!(sub1.raw_image.len(), 21573);
     subs.next().expect("missing sub 2").unwrap();
     assert!(subs.next().is_none());
 }
@@ -673,6 +935,77 @@ fn parse_subtitles_from_subtitle_edit() {
     let mut subs = idx.subtitles();
     subs.next().expect("missing sub").unwrap();
     assert!(subs.next().is_none());
+}
+
+#[test]
+fn parse_subtitles_by_chunks() {
+    use env_logger;
+    use std::fs;
+    use std::io::prelude::*;
+
+    let _ = env_logger::init();
+    let mut f = fs::File::open("../fixtures/example.sub").unwrap();
+    let mut buffer = vec![];
+    f.read_to_end(&mut buffer).unwrap();
+
+    // 1. Attempt to read the first subtitle
+    // with a chunk too short to retrieve the first packet.
+    let mut subs = SubtitlesFromChunks::new();
+    {
+        let mut sub_iter = subs.iter(&buffer[..100]);
+        assert!(sub_iter.next().is_none());
+    }
+    assert!(subs.expecting_chunk());
+    assert_eq!(0, subs.offset());
+
+    // 2. Attempt to read the first subtitle
+    // with a chunk large enough to retrieve the first packet, but not the second one.
+    let mut subs = SubtitlesFromChunks::new();
+    {
+        let mut sub_iter = subs.iter(&buffer[..2048 + 100]);
+        assert!(sub_iter.next().is_none());
+    }
+    assert!(subs.expecting_chunk());
+    let last_offset = subs.offset();
+    assert!(last_offset > 0);
+
+    // Add a chunk.
+    {
+        let mut sub_iter = subs.iter(&buffer[last_offset..last_offset + 3072]);
+        let sub1 = sub_iter.next()
+            .expect("missing sub 1")
+            .expect("unexpected error for sub 1");
+        assert!(sub1.start_time - 49.4 < 0.1);
+        assert!(sub1.end_time.unwrap() - 50.9 < 0.1);
+        assert_eq!(sub1.force, false);
+        assert_eq!(sub1.coordinates,
+                   Coordinates { x1: 750, y1: 916, x2: 1172, y2: 966 });
+        assert_eq!(sub1.palette, [0,3,1,0]);
+        assert_eq!(sub1.alpha, [15,15,15,0]);
+        assert_eq!(sub1.raw_image.len(), 21573);
+
+        // Missing chunk for sub 2
+        assert!(sub_iter.next().is_none());
+    }
+    assert!(subs.expecting_chunk());
+
+    // Add the rest of the buffer
+    let last_offset = last_offset + subs.offset();
+    {
+        let mut sub_iter = subs.iter(&buffer[last_offset..]);
+        let _sub2 = sub_iter.next()
+            .expect("missing sub 2")
+            .expect("unexpected error for sub 2");
+    }
+
+    // 3. Read the subtitles with a chunk large enough for the first packet
+    // and too short for the second packet's needle.
+    let mut subs = SubtitlesFromChunks::new();
+    {
+        let mut sub_iter = subs.iter(&buffer[..2048 + 2]);
+        assert!(sub_iter.next().is_none());
+    }
+    assert!(subs.expecting_chunk());
 }
 
 #[test]

--- a/vobsub/tests/parse_corpus.rs
+++ b/vobsub/tests/parse_corpus.rs
@@ -27,6 +27,25 @@ fn private_corpus() {
     }
 }
 
+// To run this test, use `cargo test -- --ignored`.  This tests against a
+// larger selection of *.sub files in our private corpus, which is
+// unfortunately not open source.
+#[test]
+#[ignore]
+fn private_corpus_by_chunks() {
+    let _ = env_logger::init();
+
+    let options = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: true,
+    };
+    for entry in glob::glob_with("../private/**/*.sub", &options).unwrap() {
+        let entry = entry.unwrap();
+        process_file_by_chunks(&entry);
+    }
+}
+
 // This corpus was generated using `cargo fuzz`, and it represents all the
 // crashes that we've found so far.
 #[test]
@@ -54,5 +73,51 @@ fn process_file(path: &Path, expect_err: bool) {
             assert_eq!(s.is_err(), expect_err);
         })
         .count();
+    debug!("Found {} subtitles", count);
+}
+
+fn process_file_by_chunks(path: &Path) {
+    use std::mem::swap;
+
+    debug!("Processing {}", path.display());
+    let mut f = fs::File::open(path).unwrap();
+
+    // Use 2 buffers in order to simulate a cheap ring buffer.
+    let capacity = 4096;
+    let mut buffer = vec![0; capacity];
+    let mut temp_buffer = vec![0; capacity];
+
+    let mut upper = 0;
+
+    let mut subs = vobsub::SubtitlesFromChunks::new();
+    let mut count = 0;
+    loop {
+        let offset = subs.offset();
+        let remaining = upper - offset;
+        if remaining > 0 {
+            // Copy bytes that are left to process at the beggining of `temp_buffer`
+            // and swap buffers so that `buffer` is always the working buffer.
+            temp_buffer[..remaining].copy_from_slice(&buffer[offset..offset + remaining]);
+            swap(&mut temp_buffer, &mut buffer);
+        }
+
+        let read_len = f.read(&mut buffer[remaining..]).expect("Failed to read file");
+        if read_len == 0 {
+            // No more data to read.
+            break;
+        }
+        upper = remaining + read_len;
+
+        let mut sub_iter = subs.iter(&buffer[0..upper]);
+        for sub in sub_iter.next() {
+            match sub {
+                Ok(_) => count += 1,
+                Err(err) => panic!("Unexpected error while parsing: {:?}", err),
+            }
+        }
+
+        debug!("{}, {:?}", subs.expecting_chunk(), subs.needed());
+    }
+
     debug!("Found {} subtitles", count);
 }

--- a/vobsub/tests/parse_corpus.rs
+++ b/vobsub/tests/parse_corpus.rs
@@ -115,8 +115,6 @@ fn process_file_by_chunks(path: &Path) {
                 Err(err) => panic!("Unexpected error while parsing: {:?}", err),
             }
         }
-
-        debug!("{}, {:?}", subs.expecting_chunk(), subs.needed());
     }
 
     debug!("Found {} subtitles", count);


### PR DESCRIPTION
This is a first step toward https://github.com/sdroege/gst-plugin-rs/issues/21

The PR adds a new `struct SubtitlesFromChunks` which keeps track of the parsing context and allows passing chunks.

Except if I missed something, the API and behaviour for `Subtitles` is unchanged. I couldn't find a solution to avoid using the `Rc<RefCell<>>` for `SubtitlesContext` without breaking the existing API.

Changes were tested using examples in "fixtures" (including for the `parse_corpus` ignored set).