### PR TITLE
Problem: tests fail on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "cli_test_dir"
-version = "0.1.4"
+version = "0.1.5"
 
 [[package]]
 name = "common_failures"
@@ -553,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "opus_tools"
 version = "0.1.3"
 dependencies = [
- "cli_test_dir 0.1.4",
+ "cli_test_dir 0.1.5",
  "common_failures 0.1.0",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -818,7 +818,7 @@ dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chardet 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cli_test_dir 0.1.4",
+ "cli_test_dir 0.1.5",
  "common_failures 0.1.0",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -879,7 +879,7 @@ dependencies = [
 name = "subtitles2srt"
 version = "0.1.0"
 dependencies = [
- "cli_test_dir 0.1.4",
+ "cli_test_dir 0.1.5",
  "common_failures 0.1.0",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1061,7 +1061,7 @@ dependencies = [
 name = "vobsub2png"
 version = "0.1.4"
 dependencies = [
- "cli_test_dir 0.1.4",
+ "cli_test_dir 0.1.5",
  "common_failures 0.1.0",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli_test_dir/Cargo.toml
+++ b/cli_test_dir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli_test_dir"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 
 description = "Tools for testing Rust command-line utilities"


### PR DESCRIPTION
Also, if a non-exe file maching binary is present in the
build directory, it'll get picked up but there'll be an error
saying that this binary is not a valid Win32 binary.

Solution: adjust tests to accommodate for Windows' ecosystem
and make the binary name automatically assume .exe extension
when compiled on Windows.