### PR TITLE
(cli_test_dir) use Display instead of Debug for std::process::ExitStatus

### DIFF
--- a/cli_test_dir/src/lib.rs
+++ b/cli_test_dir/src/lib.rs
@@ -481,7 +481,7 @@ impl ExpectStatus for process::Output {
                 .expect("could not write to stdout");
             io::stderr().write_all(&self.stderr)
                 .expect("could not write to stderr");
-            panic!("expected command to succeed, got {:?}", self.status)
+            panic!("expected command to succeed, got {}", self.status)
         }
         self
     }
@@ -492,7 +492,7 @@ impl ExpectStatus for process::Output {
                 .expect("could not write to stdout");
             io::stderr().write_all(&self.stderr)
                 .expect("could not write to stderr");
-            panic!("expected command to fail, got {:?}", self.status)
+            panic!("expected command to fail, got {}", self.status)
         }
         self
     }


### PR DESCRIPTION
On unix, the return code is stored in the upper bits of the value, so
an exit code of 1 is instead 256. With Debug, a broken
`.expect_success()` gives a misleading
`expected command to succeed, got ExitStatus(ExitStatus(256))`
and with Display it gives
`expected command to succeed, got exit code: 1`