### PR TITLE
Add cleaning of bracketed text

### DIFF
--- a/substudy/src/clean.rs
+++ b/substudy/src/clean.rs
@@ -19,7 +19,8 @@ fn clean_line(line: &str) -> String {
     //     SPEAKER:
     //     ( sound effect )
     //     ♪ music ♪
-    let clutter = Regex::new(r"(\([^)]*\)|♪[^♪]*♪|[A-Z]{2,} ?:)").unwrap();
+    //     [Music]
+    let clutter = Regex::new(r"(\([^)]*\)|\[[^\]]*\]|♪[^♪]*♪|[A-Z]{2,} ?:)").unwrap();
 
     // Used to compress and normalize consecutive whitespace.
     let whitespace = Regex::new(r"\s+").unwrap();
@@ -92,6 +93,10 @@ They've arrived.
 21
 00:01:12,839 --> 00:01:13,840
 ♪ ♪
+
+22
+00:01:14,432 --> 00:01:16,637
+[Music]
 
 18
 00:01:02,328 --> 00:01:03,162


### PR DESCRIPTION
Adds cleaning of bracketed text such as `[Music]` to the `substudy clean` command. This text is found on YouTube video subtitles such as the start of [this video](https://www.youtube.com/watch?v=v2e8klIhpFs). Let me know if you want me to remove the test case I added to `substudy/src/clean.rs` or if there is a better place to put it. Thanks for making this project!